### PR TITLE
Tmrca hist

### DIFF
--- a/src/interactive_plot.py
+++ b/src/interactive_plot.py
@@ -72,8 +72,7 @@ class LinkedView(plugins.PluginBase):
             histline.data[i+1][1] = histdata[tri_index][i];        
         }
         histline.elements().transition()
-            .attr("d", histline.datafunc(histline.data))
-            .style("stroke", this.style.fill);
+            .attr("d", histline.datafunc(histline.data));
         meanline.data[0][0] = meandata[tri_index];
         meanline.data[1][0] = meandata[tri_index];
         meanline.elements().transition()
@@ -126,6 +125,11 @@ assert row_order==col_order
 # Require python 3.6 so that dict retains order
 order = {o:mean_tmrca_df.columns[o] for o in col_order}
 
+legend = result.ax_cbar
+pos1 = legend.get_position() # get the original position 
+pos2 = [pos1.x0+0.04,  pos1.y0-0.06, pos1.width, pos1.height*1.5]
+legend.set_position(pos2)
+
 mesh_obj = heatmap_plot.collections[0]
 histogram_plot = result.ax_col_dendrogram  # put the histogram where the column dendrogram normally goes
 histogram_plot.clear()
@@ -140,7 +144,7 @@ histogram_plot.set_xticklabels([1e3, 2e3, 5e3, 1e4, 2e4, 5e4, 1e5])
 
 x, y = np.append(bins, bins[-1]), np.pad(np.zeros(dist_tmrcas.shape[1]), 1) # initial hist is all at 0
 # create the histogram as a line object (easier to manipulate)
-histogram_plot.step(x, y, '-')
+histogram_plot.step(x, y, '-', color='k')
 # Add a line at the mean
 histogram_plot.plot([0, 0], [0, 1], linewidth=4, color='w')  # Hide the mean line marker by making it white
 histogram_plot.text(bins[1], 1.5, " ", verticalalignment='top')

--- a/src/interactive_plot.py
+++ b/src/interactive_plot.py
@@ -1,0 +1,165 @@
+import warnings
+
+import numpy as np
+import seaborn as sns
+import pandas as pd
+import matplotlib.gridspec
+import matplotlib.pyplot as plt
+import mpld3
+from mpld3 import plugins, utils
+#mpld3.enable_notebook() # if in a jupyter notebook - also needs %matplotlib inline
+
+# Get data and massage it to the right format
+base_filename = "all-data/merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic.20nodes.tmrcas"
+mean_tmrca_df = pd.read_csv(base_filename + ".csv", index_col=0)
+# Flatten the upper triangular means and log (also matches the hist data)
+mean_tmrcas = np.log(mean_tmrca_df.values[np.triu_indices(mean_tmrca_df.shape[0])])
+histdata_tmrcas = np.load(base_filename + ".npz") # Rows are arranged as [(0, 0), (0, 1), (0, 2), (0, 3), (1, 1), (1, 2), (1, 3), (2, 2), (2, 3), (3, 3)]
+dist_tmrcas = histdata_tmrcas['histdata']
+bins = histdata_tmrcas['bins']
+
+
+for row in range(mean_tmrca_df.shape[1]):
+    for col in range(row+1, mean_tmrca_df.shape[0]):
+       mean_tmrca_df.iloc[col, row] = mean_tmrca_df.iloc[row, col]
+
+
+class LinkedView(plugins.PluginBase):
+    """A plugin showing how multiple axes can be linked"""
+
+    def css(self):
+        # Not sure why this doesn't work
+        return """
+            .mpld3-xaxis .tick text {transform: "rotate(90)"}
+            """
+
+    JAVASCRIPT = """
+    mpld3.register_plugin("linkedview", LinkedViewPlugin);
+    LinkedViewPlugin.prototype = Object.create(mpld3.Plugin.prototype);
+    LinkedViewPlugin.prototype.constructor = LinkedViewPlugin;
+    LinkedViewPlugin.prototype.requiredProps = [
+        "idpts", "idlab", "idline", "idmean", "histdata", "meandata", "order", "labels"];
+    LinkedViewPlugin.prototype.defaultProps = {}
+    function LinkedViewPlugin(fig, props){
+        mpld3.Plugin.call(this, fig, props);
+    };
+
+    LinkedViewPlugin.prototype.draw = function(){
+      var pts = mpld3.get_element(this.props.idpts);
+      var histlabel = mpld3.get_element(this.props.idlab);
+      var histline = mpld3.get_element(this.props.idline);
+      var meanline = mpld3.get_element(this.props.idmean);
+      var histdata = this.props.histdata;
+      var meandata = this.props.meandata;
+      var order = this.props.order;
+      var labels = this.props.labels;
+      var n_cols = order.length;
+
+      function mouseover(xy_pos, point_index){
+        var col = point_index % n_cols;
+        var row =  (point_index - col) / n_cols;
+        // There's probably a better way to set text, but at least this works
+        histlabel.obj._groups[0][0].innerHTML = labels[col] + " - " + labels[row];
+        /* convert to order used in original data */
+        col = order[col]
+        row = order[row]
+        /* convert to upper triangular index */
+        if (row > col) {
+            [row, col] = [col, row]; 
+        }
+        var tri_index = (n_cols*(n_cols+1)/2) - (n_cols-row)*((n_cols-row)+1)/2 + col - row
+        for (var i=0; i < histline.data.length-2; i++) {
+            histline.data[i+1][1] = histdata[tri_index][i];        
+        }
+        histline.elements().transition()
+            .attr("d", histline.datafunc(histline.data))
+            .style("stroke", this.style.fill);
+        meanline.data[0][0] = meandata[tri_index];
+        meanline.data[1][0] = meandata[tri_index];
+        meanline.elements().transition()
+            .attr("d", meanline.datafunc(meanline.data))
+            .style("stroke", this.style.fill);
+
+      }
+      pts.elements().on("mouseover", mouseover);
+    };
+    """
+
+    def __init__(self, points, histlabel, histline, meanline, histdata, meandata, order):
+        if isinstance(points, matplotlib.lines.Line2D):
+            suffix = "pts"
+        else:
+            suffix = None
+        self.dict_ = {
+            "type": "linkedview",
+            "idpts": utils.get_id(points, suffix),
+            "idlab": utils.get_id(histlabel),
+            "idline": utils.get_id(histline),
+            "idmean": utils.get_id(meanline),
+            "histdata": histdata,
+            "meandata": meandata,
+            "order": list(order.keys()),
+            "labels": list(order.values()),
+        }
+        
+result = sns.clustermap(
+    mean_tmrca_df,
+    method="average",
+    linewidths = 0,
+    rasterized=True,
+    cmap=plt.cm.inferno_r,
+    xticklabels=1,
+    yticklabels=0,
+)
+heatmap_plot = result.ax_heatmap
+result.cax.tick_params(labelsize=8)
+result.cax.set_xlabel("Average TMRCA (generations)", size=10)
+heatmap_plot.set_xticklabels(result.ax_heatmap.get_xmajorticklabels(), fontsize=7)
+
+# Clustermap reorders the cols & rows, so we must use the new order for the source data
+row_order = getattr(result.dendrogram_row, 'reordered_ind', np.arange(mean_tmrca_df.shape[0]))
+col_order = getattr(result.dendrogram_col, 'reordered_ind', np.arange(mean_tmrca_df.shape[1]))
+assert row_order==col_order
+# Require python 3.6 so that dict retains order
+order = {o:mean_tmrca_df.columns[o] for o in col_order}
+
+mesh_obj = heatmap_plot.collections[0]
+histogram_plot = result.ax_col_dendrogram  # put the histogram where the column dendrogram normally goes
+histogram_plot.clear()
+
+# Change histogram axis position to make room for X axis
+pos1 = histogram_plot.get_position() # get the original position 
+pos2 = [pos1.x0, pos1.y0+0.05,  pos1.width, pos1.height/1.3]
+histogram_plot.set_position(pos2) # set a new position
+histogram_plot.set_xlabel("tMRCA (generations)")
+histogram_plot.set_xticks(np.log([1e3, 2e3, 5e3, 1e4, 2e4, 5e4, 1e5]))
+histogram_plot.set_xticklabels([1e3, 2e3, 5e3, 1e4, 2e4, 5e4, 1e5])
+
+x, y = np.append(bins, bins[-1]), np.pad(np.zeros(dist_tmrcas.shape[1]), 1) # initial hist is all at 0
+# create the histogram as a line object (easier to manipulate)
+histogram_plot.step(x, y, '-')
+# Add a line at the mean
+histogram_plot.plot([0, 0], [0, 1], linewidth=4, color='w')  # Hide the mean line marker by making it white
+histogram_plot.text(bins[1], 1.5, " ", verticalalignment='top')
+hist_line = histogram_plot.lines[0]
+mean_line = histogram_plot.lines[1]
+hist_label = histogram_plot.texts[0]
+
+histogram_plot.set_ylim(0, 1.5)
+histogram_plot.set_xlim(bins[0], bins[-1])
+
+plugins.connect(
+    result.fig,
+    LinkedView(
+        mesh_obj,
+        hist_label,
+        hist_line,
+        mean_line,
+        # round the histogram values to save file space
+        np.round(dist_tmrcas, 4),
+        np.round(mean_tmrcas, 5), order))
+with warnings.catch_warnings():
+    # mpld3 triggers DeprecationWarning: np.asscalar
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    mpld3.save_html(result.fig, base_filename + ".html")
+    # mpld3.show() # For notebooks

--- a/src/interactive_plot.py
+++ b/src/interactive_plot.py
@@ -115,6 +115,9 @@ heatmap_plot = result.ax_heatmap
 result.cax.tick_params(labelsize=8)
 result.cax.set_xlabel("Average TMRCA (generations)", size=10)
 heatmap_plot.set_xticklabels(result.ax_heatmap.get_xmajorticklabels(), fontsize=7)
+heatmap_plot.invert_xaxis()
+heatmap_plot.invert_yaxis()
+result.ax_row_dendrogram.invert_yaxis()
 
 # Clustermap reorders the cols & rows, so we must use the new order for the source data
 row_order = getattr(result.dendrogram_row, 'reordered_ind', np.arange(mean_tmrca_df.shape[0]))

--- a/src/tmrcas.py
+++ b/src/tmrcas.py
@@ -8,15 +8,17 @@ from tqdm import tqdm
 import collections
 
 def get_pairwise_tmrca_pops(
-    ts, hist_nbins=30, hist_min_gens=1000, return_full_data=False
+    ts_name, max_pop_nodes, hist_nbins=30, hist_min_gens=1000, return_full_data=False
 ):
     """
+    max_pop_nodes gives the maximum number of sample nodes per pop to use
     hist_nbins determines the number of bins used to save the histogram data,
     hist_min_gens gives a lower cutoff for the histogram bins, as there is usually
     very little in the lowest (logged) bins
     if return_full_data is True, also return the full dataset of weights (which may be
     huge, as it is ~ num_unique_times * n_pops * n_pops /2
     """
+    ts = tskit.load(ts_name)
     deleted_trees = [tree.index for tree in ts.trees() if tree.parent(0) == -1]  
     node_ages = np.zeros_like(ts.tables.nodes.time[:])
     metadata = ts.tables.nodes.metadata[:]
@@ -41,28 +43,34 @@ def get_pairwise_tmrca_pops(
     # Make a random selection of up to 10 samples from each population
     np.random.seed(123)
     pop_nodes = ts.tables.nodes.population[ts.samples()]
-    pop_nodes = [np.where(pop_nodes == pop.id)[0] for pop in ts.populations()]
-    rand_nodes = list()
-    for nodes in pop_nodes:
-        if len(nodes) > 20:
-            rand_nodes.append(np.random.choice(nodes, 20, replace=False))
+    nodes_for_pop = {}
+    for pop in ts.populations():
+        metadata = json.loads(pop.metadata)
+        key = metadata["name"]
+        # Hack to distinguish SGDP from HGDP (all uppercase) pop names
+        if 'region' in metadata and not metadata['region'].isupper():
+            key += " (SGDP)" 
+        assert key not in nodes_for_pop  # Check for duplicate names
+        nodes = np.where(pop_nodes == pop.id)[0]
+        if len(nodes) > max_pop_nodes:
+            nodes_for_pop[key] = np.random.choice(nodes, max_pop_nodes, replace=False)
         else:
-            rand_nodes.append(nodes)
+            nodes_for_pop[key] = nodes
     
     # Make all combinations of populations
-    pop_names = [json.loads(pop.metadata)["name"] for pop in ts.populations()]
+    pop_names = list(nodes_for_pop.keys())
     tmrca_df = pd.DataFrame(columns=pop_names, index=pop_names)
-    combos = itertools.combinations_with_replacement(np.arange(0, ts.num_populations), 2)
+    combos = itertools.combinations_with_replacement(np.arange(0, len(pop_names)), 2)
     combo_map = {c: i for i, c in enumerate(combos)}
     func_params = zip(
         combo_map.keys(),
         itertools.repeat(time_index),
-        itertools.repeat(rand_nodes),
-        itertools.repeat(ts),
+        itertools.repeat(list(nodes_for_pop.values())),
+        itertools.repeat(ts_name),
         itertools.repeat(deleted_trees),
     )
     data = np.zeros((len(combo_map), len(unique_times)), dtype=np.float)
-    with multiprocessing.Pool(processes=2) as pool: 
+    with multiprocessing.Pool(processes=64) as pool: 
         for tmrca_weight, combo in tqdm(
             pool.imap_unordered(get_tmrca_weights, func_params), total=len(combo_map)
         ):
@@ -75,10 +83,14 @@ def get_pairwise_tmrca_pops(
             data[combo_map[combo], :] = tmrca_weight
     bins, hist_data = make_histogram_data(
         log_unique_times, data, hist_nbins, hist_min_gens)
+    named_combos = [None] * len(combo_map)
+    for combo, i in combo_map.items():
+        named_combos[i] = (pop_names[combo[0]], pop_names[combo[1]])
+    named_combos = np.array(named_combos)
     if return_full_data:
-        return tmrca_df, bins, hist_data, data
+        return tmrca_df, bins, hist_data, named_combos, data
     else:
-        return tmrca_df, bins, hist_data
+        return tmrca_df, bins, hist_data, named_combos
 
 def make_histogram_data(log_unique_times, data, hist_nbins, hist_min_gens):
     """
@@ -86,7 +98,7 @@ def make_histogram_data(log_unique_times, data, hist_nbins, hist_min_gens):
     re-calculating with different bin widths etc.
     """
     av_weight = np.mean(data, axis=0)
-    keep == (av_weight != 0)
+    keep = (av_weight != 0)
     #Make common breaks for histograms
     _, bins = np.histogram(
         log_unique_times[keep],
@@ -94,9 +106,9 @@ def make_histogram_data(log_unique_times, data, hist_nbins, hist_min_gens):
         bins=hist_nbins,
         range=[np.log(hist_min_gens), max(log_unique_times)],
         density=True)
-    hist_data = np.zeros((len(combo_map), hist_nbins), dtype=np.float32)
+    hist_data = np.zeros((data.shape[0], hist_nbins), dtype=np.float32)
     for i, row in enumerate(data):
-        hist_data[i, :] = np.histogram(
+        hist_data[i, :], _ = np.histogram(
             log_unique_times[keep],
             weights=row[keep],
             bins=bins,
@@ -105,7 +117,8 @@ def make_histogram_data(log_unique_times, data, hist_nbins, hist_min_gens):
     return bins, hist_data
 
 def get_tmrca_weights(params):
-    combo, time_index, rand_nodes, ts, deleted_trees = params
+    combo, time_index, rand_nodes, ts_name, deleted_trees = params
+    ts = tskit.load(ts_name)
     pop_0 = combo[0]
     pop_1 = combo[1]
     num_unique_times = max(time_index) + 1
@@ -125,12 +138,12 @@ def get_tmrca_weights(params):
     return tmrca_weight, combo
 
 if __name__ == '__main__':
-    file = "all-data/merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic"
-    ts = tskit.load(file + ".trees")
-    
-    tmrca_df, bins, hist_data = get_pairwise_tmrca_pops(ts)
-    outfile = file + ".tmrcas"
-    print(f"Writing mean MRCAs to {outfile}.csv")
-    tmrca_df.to_csv(outfile + ".csv")
-    print(f"Writing bins and MRCA histogram distributions to {outfile}.npz")
-    np.savez_compressed(outfile + ".npz", bins=bins, hist_data=hist_data)
+    fn = "all-data/merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic"
+    ts_name = fn + ".trees"
+    max_pop_nodes = 20
+    tmrca_df, bins, histdata, combos = get_pairwise_tmrca_pops(ts_name, max_pop_nodes)
+    outfn = fn + f".{max_pop_nodes}nodes.tmrcas"
+    print(f"Writing mean MRCAs to {outfn}.csv")
+    tmrca_df.to_csv(outfn + ".csv")
+    print(f"Writing bins and MRCA histogram distributions to {outfn}.npz")
+    np.savez_compressed(outfn + ".npz", bins=bins, histdata=histdata, combos=combos)

--- a/src/tmrcas.py
+++ b/src/tmrcas.py
@@ -7,70 +7,130 @@ import itertools
 from tqdm import tqdm
 import collections
 
-ts = tskit.load("merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic.trees")
+def get_pairwise_tmrca_pops(
+    ts, hist_nbins=30, hist_min_gens=1000, return_full_data=False
+):
+    """
+    hist_nbins determines the number of bins used to save the histogram data,
+    hist_min_gens gives a lower cutoff for the histogram bins, as there is usually
+    very little in the lowest (logged) bins
+    if return_full_data is True, also return the full dataset of weights (which may be
+    huge, as it is ~ num_unique_times * n_pops * n_pops /2
+    """
+    deleted_trees = [tree.index for tree in ts.trees() if tree.parent(0) == -1]  
+    node_ages = np.zeros_like(ts.tables.nodes.time[:])
+    metadata = ts.tables.nodes.metadata[:]
+    metadata_offset = ts.tables.nodes.metadata_offset[:]
+    try:
+        for index, met in enumerate(tskit.unpack_bytes(metadata, metadata_offset)):
+            if index not in ts.samples():
+                try:
+                    # Get unconstrained node age if available
+                    node_ages[index] = json.loads(met.decode())["mn"]
+                except json.decoder.JSONDecodeError:
+                    raise ValueError(
+                            "Tree Sequence must be dated to use unconstrained=True")
+        print("Using tsdate unconstrained node times")
+    except KeyError:
+        print("Using standard ts node times")
+        node_ages[:] = ts.tables.nodes.time[:]
+    unique_times, time_index = np.unique(node_ages, return_inverse=True)
+    with np.errstate(divide='ignore'):
+        log_unique_times = np.log(unique_times)
 
-node_ages = ts.tables.nodes.time[:]
-deleted_trees = [tree.index for tree in ts.trees() if tree.parent(0) == -1]  
-
-metadata = ts.tables.nodes.metadata[:]
-metadata_offset = ts.tables.nodes.metadata_offset[:]
-for index, met in enumerate(tskit.unpack_bytes(metadata, metadata_offset)):
-    if index not in ts.samples():
-        try:
-            node_ages[index] = json.loads(met.decode())["mn"]
-        except json.decoder.JSONDecodeError:
-            raise ValueError(
-                    "Tree Sequence must be dated to use unconstrained=True")
-pop_nodes = ts.tables.nodes.population[ts.samples()]
-pop_nodes = [np.where(pop_nodes == pop.id)[0] for pop in ts.populations()]
-rand_nodes = list()
-for nodes in pop_nodes:
-    if len(nodes) > 20:
-        rand_nodes.append(np.random.choice(nodes, 20, replace=False))
-    else:
-        rand_nodes.append(nodes)
-
-
-def get_pairwise_tmrca_pops(ts):
+    # Make a random selection of up to 10 samples from each population
+    np.random.seed(123)
+    pop_nodes = ts.tables.nodes.population[ts.samples()]
+    pop_nodes = [np.where(pop_nodes == pop.id)[0] for pop in ts.populations()]
+    rand_nodes = list()
+    for nodes in pop_nodes:
+        if len(nodes) > 20:
+            rand_nodes.append(np.random.choice(nodes, 20, replace=False))
+        else:
+            rand_nodes.append(nodes)
+    
+    # Make all combinations of populations
     pop_names = [json.loads(pop.metadata)["name"] for pop in ts.populations()]
-    if input == "1kg_sgdp_hgdp":
-        pop_name_suffixes = pop_names[0:26]
-        for pop in pop_names[26:156]:
-            pop_name_suffixes.append(pop + "_SGDP")
-        for pop in pop_names[156:]:
-            pop_name_suffixes.append(pop + "_HGDP")
-        pop_names = pop_name_suffixes
     tmrca_df = pd.DataFrame(columns=pop_names, index=pop_names)
-    pop_rows = list()
-    combos = list(itertools.combinations_with_replacement(np.arange(0, ts.num_populations),2))
-    weights = np.array([tree.span for tree in ts.trees() if tree.index not in deleted_trees])
-    with multiprocessing.Pool(processes=10) as pool: 
-        for avg_tmrca, combo in tqdm(pool.imap_unordered(get_avg_tmrca, combos), total=len(combos)):
-            tmrca_df.loc[pop_names[combo[0]], pop_names[combo[1]]] = np.exp(np.average(np.log(avg_tmrca), weights=weights))
-    return tmrca_df
+    combos = itertools.combinations_with_replacement(np.arange(0, ts.num_populations), 2)
+    combo_map = {c: i for i, c in enumerate(combos)}
+    func_params = zip(
+        combo_map.keys(),
+        itertools.repeat(time_index),
+        itertools.repeat(rand_nodes),
+        itertools.repeat(ts),
+        itertools.repeat(deleted_trees),
+    )
+    data = np.zeros((len(combo_map), len(unique_times)), dtype=np.float)
+    with multiprocessing.Pool(processes=2) as pool: 
+        for tmrca_weight, combo in tqdm(
+            pool.imap_unordered(get_tmrca_weights, func_params), total=len(combo_map)
+        ):
+            popA = pop_names[combo[0]]
+            popB = pop_names[combo[1]]
+            keep = (tmrca_weight != 0)  # Deal with log_unique_times[0] == -inf
+            mean_log_age = np.sum(log_unique_times[keep] * tmrca_weight[keep])
+            mean_log_age /= np.sum(tmrca_weight) # Normalise
+            tmrca_df.loc[popA, popB] = np.exp(mean_log_age)
+            data[combo_map[combo], :] = tmrca_weight
+    bins, hist_data = make_histogram_data(
+        log_unique_times, data, hist_nbins, hist_min_gens)
+    if return_full_data:
+        return tmrca_df, bins, hist_data, data
+    else:
+        return tmrca_df, bins, hist_data
 
-def get_avg_tmrca(combo):
-    avg_tmrca = []
+def make_histogram_data(log_unique_times, data, hist_nbins, hist_min_gens):
+    """
+    NB: this can also be called on the (saved) full data matrix, if histograms need
+    re-calculating with different bin widths etc.
+    """
+    av_weight = np.mean(data, axis=0)
+    keep == (av_weight != 0)
+    #Make common breaks for histograms
+    _, bins = np.histogram(
+        log_unique_times[keep],
+        weights=av_weight[keep],
+        bins=hist_nbins,
+        range=[np.log(hist_min_gens), max(log_unique_times)],
+        density=True)
+    hist_data = np.zeros((len(combo_map), hist_nbins), dtype=np.float32)
+    for i, row in enumerate(data):
+        hist_data[i, :] = np.histogram(
+            log_unique_times[keep],
+            weights=row[keep],
+            bins=bins,
+            density=True,
+        )
+    return bins, hist_data
+
+def get_tmrca_weights(params):
+    combo, time_index, rand_nodes, ts, deleted_trees = params
     pop_0 = combo[0]
     pop_1 = combo[1]
+    num_unique_times = max(time_index) + 1
     pop_0_nodes = rand_nodes[pop_0]
     if pop_0 != pop_1:
         pop_1_nodes = rand_nodes[pop_1]
         node_combos = [(x, y) for x in pop_0_nodes for y in pop_1_nodes]
     elif pop_0 == pop_1:
         node_combos = list(itertools.combinations(pop_0_nodes, 2))
-    avg_tmrca = np.zeros((ts.num_trees - len(deleted_trees), len(node_combos)))
+    # Return the weights 
+    tmrca_weight = np.zeros(num_unique_times, dtype=np.float)
 
-    t_index = 0
     for tree in ts.trees(): 
         if tree.index not in deleted_trees:
-            tree_tmrcas = []
             for index, (node_0, node_1) in enumerate(node_combos):
-                avg_tmrca[t_index, index] = node_ages[tree.mrca(node_0, node_1)]
-            t_index += 1
-    avg_tmrca = np.exp(np.mean(np.log(avg_tmrca), axis=1))
-    return avg_tmrca, combo
+                tmrca_weight[time_index[tree.mrca(node_0, node_1)]] += tree.span
+    return tmrca_weight, combo
 
-
-df = get_pairwise_tmrca_pops(ts)
-df.to_csv("all-data/merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic.tmrcas")
+if __name__ == '__main__':
+    file = "all-data/merged_hgdp_1kg_sgdp_high_cov_ancients_chr20.dated.binned.historic"
+    ts = tskit.load(file + ".trees")
+    
+    tmrca_df, bins, hist_data = get_pairwise_tmrca_pops(ts)
+    outfile = file + ".tmrcas"
+    print(f"Writing mean MRCAs to {outfile}.csv")
+    tmrca_df.to_csv(outfile + ".csv")
+    print(f"Writing bins and MRCA histogram distributions to {outfile}.npz")
+    np.savez_compressed(outfile + ".npz", bins=bins, hist_data=hist_data)


### PR DESCRIPTION
This changes the tmrca calculation to include distribution data for histograms, and includes a new `interactive_plot.py` script which makes the heatmap with interactive histogram (now with a timescale, hurrah!). Unfortunately running `tmrca.py` now takes about 12hrs to run on cycloid with all 64 threads. It might be improved by using Georgia's IBD code, though, so might not be worth optimising yet.