### PR TITLE
Truncate ancestors

### DIFF
--- a/all-data/Makefile
+++ b/all-data/Makefile
@@ -481,7 +481,8 @@ archaics_phased_GRCh38_%.vcf.gz: altai.%_mq25_mapab100.vcf.gz chagyrskaya.%.noRB
 		../tools/bin/tabix -p vcf chagyrskaya.$*.vcf.gz
 		# Merge the high coverage archaics
 		../tools/bin/bcftools merge altai.$*_mq25_mapab100.vcf.gz chagyrskaya.$*.vcf.gz \
-			vindija.$*_mq25_mapab100.vcf.gz denisovan.$*_mq25_mapab100.vcf.gz -O z -o archaics_merged_$*.vcf.gz
+			vindija.$*_mq25_mapab100.vcf.gz denisovan.$*_mq25_mapab100.vcf.gz -O z \
+			-o archaics_merged_$*.vcf.gz &> high_cov_archaics_merge.$*.log
 		# Some chromosomes have non-acgt ref alleles
 		../tools/bin/plink --vcf archaics_merged_$*.vcf.gz --snps-only just-acgt --recode vcf bgz --out archaics_merged_$*.snps.only
 		# Perform phasing

--- a/all-data/Makefile
+++ b/all-data/Makefile
@@ -18,6 +18,8 @@ all: 1kg_chr20.dated.trees hgdp_1kg_sgdp_high_cov_ancients_dated_chr20.trees
 # Save all intermediate files
 .SECONDARY:
 
+# Allow filtering in prerequisites
+.SECONDEXPANSION:
 
 ####################################################
 # Standard pipeline for samples file to .dated.trees
@@ -25,6 +27,12 @@ all: 1kg_chr20.dated.trees hgdp_1kg_sgdp_high_cov_ancients_dated_chr20.trees
 
 %.missing_binned.samples: %.samples
 		python3 bin_missing.py $^ $@
+
+%_p.missing_binned.samples: %.missing_binned.samples
+		python tsutil.py split-chromosome $^ $@ $* p centromeres.csv 
+
+%_q.missing_binned.samples: %.missing_binned.samples
+		python tsutil.py split-chromosome $^ $@ $* q centromeres.csv 
 
 1kg_chr20.trees: 1kg_chr20.samples
 		python3 ../src/run_inference.py $^ -t ${NUM_THREADS} -A 1 -S 1
@@ -326,7 +334,7 @@ loshbour.%_mq25_mapab100.vcf.gz:
 ust_ishim.%_mq25_mapab100.GRCh38.vcf.gz: ust_ishim.%_mq25_mapab100.vcf.gz hg38.fa hg19ToHg38.over.chain.gz
 		gunzip -c ust_ishim.$*_mq25_mapab100.vcf.gz | awk '{if($$0 !~ /^#/) print "chr"$$0; else print $$0}' > ust_ishim.$*_mq25_mapab100.withchr.vcf
 		java -jar ../tools/picard.jar LiftoverVcf I=ust_ishim.$*_mq25_mapab100.withchr.vcf O=ust_ishim.$*_mq25_mapab100.GRCh38.vcf \
-			CHAIN=hg19ToHg38.over.chain.gz REJECT=ust_ishim.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa
+			CHAIN=hg19ToHg38.over.chain.gz REJECT=ust_ishim.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa RECOVER_SWAPPED_REF_ALT=TRUE &> picard.ust_ishim.$*.log
 		rm ust_ishim.$*_mq25_mapab100.withchr.vcf
 		../tools/bin/bgzip -c ust_ishim.$*_mq25_mapab100.GRCh38.vcf > ust_ishim.$*_mq25_mapab100.GRCh38.all.vcf.gz 
 		../tools/bin/tabix -p vcf ust_ishim.$*_mq25_mapab100.GRCh38.all.vcf.gz
@@ -348,7 +356,7 @@ ust_ishim_GRCh38_%.samples: ust_ishim.%_mq25_mapab100.GRCh38.vcf.gz %_ancestral_
 lbk.%_mq25_mapab100.GRCh38.vcf.gz: lbk.%_mq25_mapab100.vcf.gz hg38.fa hg19ToHg38.over.chain.gz
 		gunzip -c lbk.$*_mq25_mapab100.vcf.gz | awk '{if($$0 !~ /^#/) print "chr"$$0; else print $$0}' > lbk.$*_mq25_mapab100.withchr.vcf
 		java -jar ../tools/picard.jar LiftoverVcf I=lbk.$*_mq25_mapab100.withchr.vcf O=lbk.$*_mq25_mapab100.GRCh38.vcf \
-			CHAIN=hg19ToHg38.over.chain.gz REJECT=lbk.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa
+			CHAIN=hg19ToHg38.over.chain.gz REJECT=lbk.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa RECOVER_SWAPPED_REF_ALT=TRUE &> picard.lbk.$*.log
 		rm lbk.$*_mq25_mapab100.withchr.vcf
 		../tools/bin/bgzip -c lbk.$*_mq25_mapab100.GRCh38.vcf > lbk.$*_mq25_mapab100.GRCh38.all.vcf.gz 
 		../tools/bin/tabix -p vcf lbk.$*_mq25_mapab100.GRCh38.all.vcf.gz
@@ -370,7 +378,7 @@ lbk_GRCh38_%.samples: lbk.%_mq25_mapab100.GRCh38.vcf.gz %_ancestral_states.fa.fa
 loshbour.%_mq25_mapab100.GRCh38.vcf.gz: loshbour.%_mq25_mapab100.vcf.gz hg38.fa hg19ToHg38.over.chain.gz
 		gunzip -c loshbour.$*_mq25_mapab100.vcf.gz | awk '{if($$0 !~ /^#/) print "chr"$$0; else print $$0}' > loshbour.$*_mq25_mapab100.withchr.vcf
 		java -jar ../tools/picard.jar LiftoverVcf I=loshbour.$*_mq25_mapab100.withchr.vcf O=loshbour.$*_mq25_mapab100.GRCh38.vcf \
-			CHAIN=hg19ToHg38.over.chain.gz REJECT=loshbour.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa
+			CHAIN=hg19ToHg38.over.chain.gz REJECT=loshbour.$*_mq25_mapab100.GRCh38.rejected_variants.vcf R=hg38.fa RECOVER_SWAPPED_REF_ALT=TRUE &> picard.loshbour.$*.log
 		rm loshbour.$*_mq25_mapab100.withchr.vcf
 		../tools/bin/bgzip -c loshbour.$*_mq25_mapab100.GRCh38.vcf > loshbour.$*_mq25_mapab100.GRCh38.all.vcf.gz 
 		../tools/bin/tabix -p vcf loshbour.$*_mq25_mapab100.GRCh38.all.vcf.gz
@@ -480,10 +488,10 @@ archaics_phased_GRCh38_%.vcf.gz: altai.%_mq25_mapab100.vcf.gz chagyrskaya.%.noRB
 		java -Xmx100g -jar ../tools/beagle.18May20.d20.jar gt=archaics_merged_$*.snps.only.vcf.gz \
 			out=archaics_phased_$* map=plink.$*.GRCh37.map nthreads=20
 		gunzip -c archaics_phased_$*.vcf.gz | awk '{if($$0 !~ /^#/) print "chr"$$0; else print $$0}' > archaics_phased_$*.withchr.vcf
-		# Liftover to GRCh38
+		## Liftover to GRCh38
 		java -jar ../tools/picard.jar LiftoverVcf I=archaics_phased_$*.withchr.vcf \
 			O=archaics_phased_$*.GRCh38.vcf CHAIN=hg19ToHg38.over.chain.gz \
-			REJECT=archaics_phased_$*.GRCh38.rejected_variants.vcf R=hg38.fa
+			REJECT=archaics_phased_$*.GRCh38.rejected_variants.vcf R=hg38.fa RECOVER_SWAPPED_REF_ALT=TRUE &> picard.archaics_phased.$*.log
 		rm archaics_phased_$*.withchr.vcf
 		../tools/bin/bgzip -c archaics_phased_$*.GRCh38.vcf > archaics_phased_$*.GRCh38.all.vcf.gz 
 		../tools/bin/tabix -p vcf archaics_phased_$*.GRCh38.all.vcf.gz
@@ -525,7 +533,8 @@ AfanasievoFamily_%.phased.detailed.filtered.GRCh38.vcf.gz: AfanasievoFamily_%${V
 			AfanasievoFamily_$*${VCF_SUFFIX}.withchr.vcf
 		java -jar ../tools/picard.jar LiftoverVcf I=AfanasievoFamily_$*${VCF_SUFFIX}.withchr.vcf \
 			O=AfanasievoFamily_$*${VCF_SUFFIX}.liftedover.GRCh38.vcf \
-			CHAIN=hg19ToHg38.over.chain.gz REJECT=AfanasievoFamily_$*${VCF_SUFFIX}.phased.GRCh38.rejected_variants.vcf R=hg38.fa
+			CHAIN=hg19ToHg38.over.chain.gz REJECT=AfanasievoFamily_$*${VCF_SUFFIX}.phased.GRCh38.rejected_variants.vcf R=hg38.fa \
+			RECOVER_SWAPPED_REF_ALT=TRUE &> picard.afanasievo.$*.log
 		rm AfanasievoFamily_$*${VCF_SUFFIX}.withchr.vcf
 		../tools/bin/bgzip -c AfanasievoFamily_$*${VCF_SUFFIX}.liftedover.GRCh38.vcf > AfanasievoFamily_$*${VCF_SUFFIX}.liftedover.GRCh38.vcf.gz
 		../tools/bin/tabix -f -p vcf AfanasievoFamily_$*${VCF_SUFFIX}.liftedover.GRCh38.vcf.gz
@@ -587,13 +596,13 @@ reich_ancients_%.samples: reich_%.samples
 v42.4.1240K_GRCh38_%.vcf.gz: v42.4.1240K_%.vcf.gz hg38.fa hg19ToHg38.over.chain.gz
 		gunzip -c v42.4.1240K_$*.vcf.gz > v42.4.1240K_$*.vcf
 		awk '{if($$0 !~ /^#/) print "chr"$$0; else print $$0}' v42.4.1240K_$*.vcf > v42.4.1240K_$*.withchr.vcf
-		java -Xmx100G -jar ../tools/picard.jar LiftoverVcf \
+		java -Xmx200G -jar ../tools/picard.jar LiftoverVcf \
 				INPUT=v42.4.1240K_$*.withchr.vcf \
 				OUTPUT=v42.4.1240K_GRCh38_$*.vcf \
 				CHAIN=hg19ToHg38.over.chain.gz \
 				REJECT=v42.4.1240K_GRCh38_$*.rejected_variants.vcf \
 				R=hg38.fa \
-				RECOVER_SWAPPED_REF_ALT=true
+				RECOVER_SWAPPED_REF_ALT=TRUE &> picard.v42.4.1240K.$*.log
 		../tools/bin/bgzip -c v42.4.1240K_GRCh38_$*.vcf > v42.4.1240K_GRCh38_$*.all.vcf.gz 
 		rm v42.4.1240K_GRCh38_$*.vcf
 		../tools/bin/tabix -p vcf v42.4.1240K_GRCh38_$*.all.vcf.gz
@@ -633,21 +642,33 @@ hgdp_1kg_sgdp_all_ancients_%.samples: hgdp_1kg_sgdp_high_cov_ancients_%.samples 
 		python3 tsutil.py merge-sampledata-files --input-sampledata $< reich_ancients_GRCh38_$*.subset.samples \
 			ust_ishim_GRCh38_$*.subset.samples loshbour_GRCh38_$*.subset.samples lbk_GRCh38_$*.subset.samples --output $@
 
+hgdp_1kg_sgdp_high_cov_ancients_%_p.samples: hgdp_1kg_sgdp_high_cov_ancients_%.samples
+		python tsutil.py split-chromosome $^ $@ $* p centromeres.csv 
+
+hgdp_1kg_sgdp_high_cov_ancients_%_q.samples: hgdp_1kg_sgdp_high_cov_ancients_%.samples
+		python tsutil.py split-chromosome $^ $@ $* q centromeres.csv 
+
+hgdp_1kg_sgdp_all_ancients_%_p.samples: hgdp_1kg_sgdp_all_ancients_%.samples
+		python tsutil.py split-chromosome $^ $@ $* p centromeres.csv 
+
+hgdp_1kg_sgdp_all_ancients_%_q.samples: hgdp_1kg_sgdp_all_ancients_%.samples
+		python tsutil.py split-chromosome $^ $@ $* q centromeres.csv 
+
 all_ancients_%.samples: 1kg_%.samples reich_ancients_%.samples afanasievo_%.samples denisovan_%.samples vindija_%.samples \
 	chagyrskaya_%.samples altai_%.samples ust_ishim_%.samples loshbour_%.samples lbk_%.samples
 		python3 tsutil.py merge-sampledata-files --input-sampledata $^ --output $@
 
-hgdp_1kg_sgdp_high_cov_ancients_dated_%.samples: hgdp_1kg_sgdp_%.missing_binned.dated.trees hgdp_1kg_sgdp_high_cov_ancients_%.samples \
+hgdp_1kg_sgdp_high_cov_ancients_%_dated.samples: hgdp_1kg_sgdp_%.missing_binned.dated.trees hgdp_1kg_sgdp_high_cov_ancients_%.samples \
 	hgdp_1kg_sgdp_all_ancients_%.samples
 		python3 tsutil.py combined-ts-dated-samples --high-cov hgdp_1kg_sgdp_high_cov_ancients_$*.samples \
 			--all-samples hgdp_1kg_sgdp_all_ancients_$*.samples --dated-ts hgdp_1kg_sgdp_$*.missing_binned.dated.trees \
 			--output $@ > hgdp_1kg_sgdp_high_cov_ancients_dated_$*_constrained_variants.txt
 
-hgdp_1kg_sgdp_high_cov_ancients_dated_%.trees: hgdp_1kg_sgdp_high_cov_ancients_dated_%.samples recomb-hg38/
-		python3 bin_dates.py $< hgdp_1kg_sgdp_high_cov_ancients_dated_$*.binned.samples
-		python3 ../src/run_inference.py hgdp_1kg_sgdp_high_cov_ancients_dated_$*.binned.samples -t ${NUM_THREADS} -A 1 -S 1 \
+hgdp_1kg_sgdp_high_cov_ancients_%.dated.trees: hgdp_1kg_sgdp_high_cov_ancients_%_dated.samples recomb-hg38/
+		python3 bin_dates.py $< hgdp_1kg_sgdp_high_cov_ancients_$*_dated.binned.samples
+		python3 ../src/run_inference.py hgdp_1kg_sgdp_high_cov_ancients_$*_dated.binned.samples -t ${NUM_THREADS} -A 1 -S 1 \
 			-m recomb-hg38/genetic_map_GRCh38_
-		python3 tsutil.py simplify hgdp_1kg_sgdp_high_cov_ancients_dated_$*.binned.nosimplify.trees $@
+		python3 tsutil.py simplify hgdp_1kg_sgdp_high_cov_ancients_$*_dated.binned.nosimplify.trees $@
 
 clean:
 		rm -f 1kg_samples.ped sgdp_samples.txt *.vcf* *.samples* recomb-hg38/

--- a/all-data/bin_dates.py
+++ b/all-data/bin_dates.py
@@ -1,0 +1,34 @@
+"""
+Dated sample data files with missing data create ancestors at many different time points,
+often only one ancestor in each time point, which can cause difficulties parallelising
+the inference. This script takes a sampledata file (usually containing missing data),
+and bins the resulting times to the nearest 10 (unless the time is <= 1).
+"""
+
+import argparse
+
+import numpy as np
+import tsinfer
+import tskit
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file",
+        help="A tsinfer sample file ending in '.samples")
+    parser.add_argument("output_file",
+        help="A tsinfer sample file ending in '.samples")
+    args = parser.parse_args()
+
+    sd = tsinfer.load(args.input_file).copy(path=args.output_file)
+
+    times = sd.sites_time[:]
+    times[times > 1] = np.round(times[times > 1], -1)
+    times[times == 0] = 1
+    sd.sites_time[:] = times
+    print(
+        "Number of samples:",
+        sd.num_samples,
+        ". Number of discrete times:",
+        len(np.unique(sd.sites_time[:])))
+    sd.finalise()

--- a/all-data/convert.py
+++ b/all-data/convert.py
@@ -910,9 +910,9 @@ class AfanasievoConverter(MaxPlanckConverter):
             metadata = {}
             metadata["name"] = name
             if "Son" in name:
-                metadata["age"] = 4100 / GENERATION_TIME
+                metadata["age"] = 4589 / GENERATION_TIME
             else:
-                metadata["age"] = 4125 / GENERATION_TIME
+                metadata["age"] = 4614 / GENERATION_TIME
             self.samples.add_individual(
                 metadata=metadata, time=metadata["age"], population=pop_id, ploidy=2
             )

--- a/all-data/tsutil.py
+++ b/all-data/tsutil.py
@@ -598,9 +598,14 @@ def split_chromosome(args):
 
 
 def combine_chromosome_arms(args):
+    """
+    Splices two chromosome arms together to form a full chromosome
+    """
     short_arm = tskit.load(args.p_arm)
     long_arm = tskit.load(args.q_arm)
     assert short_arm.num_samples == long_arm.num_samples
+    # Remove material before first position and after last position
+    short_arm = short_arm.keep_intervals([[short_arm.tables.sites.position[0], short_arm.tables.sites.position[-1]]], simplify=False)
     long_arm = long_arm.keep_intervals([[long_arm.tables.sites.position[0], long_arm.tables.sites.position[-1]]], simplify=False)
     short_tables = short_arm.dump_tables()
     long_tables = long_arm.dump_tables()

--- a/all-data/tsutil.py
+++ b/all-data/tsutil.py
@@ -1,10 +1,11 @@
 """
-    print(args.chrom)
 Various utilities for manipulating tree sequences and running tsinfer.
 """
 import argparse
+import csv
 import time
 import collections
+import re
 import json
 import os.path
 
@@ -564,6 +565,75 @@ def combined_ts_constrained_samples(args):
     high_cov_samples_copy.finalise()
 
 
+def split_chromosome(args):
+    match = re.search(r"(chr\d+)", args.chrom)
+    if match is None:
+        raise ValueError("chr must be in filename")
+    chrom = match.group(1)
+    with open(args.centromeres) as csvfile:
+        reader = csv.DictReader(csvfile)
+        centromere_positions = list()
+        for row in reader:
+            if row["chrom"] == chrom:
+                centromere_positions.append(int(row["chromStart"]))
+                centromere_positions.append(int(row["chromEnd"]))
+    start = np.min(centromere_positions)
+    end = np.max(centromere_positions)
+    split_point = (start + end) / 2
+    samples = tsinfer.load(args.input)
+    position = samples.sites_position[:]
+    print(f"Splitting at {split_point}")
+    if args.arm == "p":
+        keep_sites = np.where(position < split_point)[0]
+        print(f"Keeping {keep_sites.shape[0]} sites")
+        arm = samples.subset(sites=keep_sites)
+        snipped_samples = arm.copy(path=args.output)
+        snipped_samples.data.attrs["sequence_length"] = split_point
+    elif args.arm == "q":
+        keep_sites = np.where(position > split_point)[0]
+        print(f"Keeping {keep_sites.shape[0]} sites")
+        arm = samples.subset(sites=keep_sites)
+        snipped_samples = arm.copy(path=args.output)
+    snipped_samples.finalise()
+
+
+def combine_chromosome_arms(args):
+    short_arm = tskit.load(args.p_arm)
+    long_arm = tskit.load(args.q_arm)
+    assert short_arm.num_samples == long_arm.num_samples
+    long_arm = long_arm.keep_intervals([[long_arm.tables.sites.position[0], long_arm.tables.sites.position[-1]]], simplify=False)
+    short_tables = short_arm.dump_tables()
+    long_tables = long_arm.dump_tables()
+    assert np.array_equal(short_tables.individuals.metadata, long_tables.individuals.metadata)
+    short_tables.sequence_length = long_arm.get_sequence_length()
+    short_tables.nodes.append_columns(long_tables.nodes.flags[~np.isin(np.arange(long_arm.num_nodes), long_arm.samples())], long_tables.nodes.time[~np.isin(np.arange(long_arm.num_nodes), long_arm.samples())])
+    long_edges_parent = long_tables.edges.parent
+    long_edges_child = long_tables.edges.child
+    long_arm_sample_map = np.zeros(long_arm.num_nodes).astype(int)
+    long_arm_sample_map[long_arm.samples()] = short_arm.samples()
+    long_edges_parent[~np.isin(long_edges_parent, long_arm.samples())] = long_edges_parent[~np.isin(long_edges_parent, long_arm.samples())] + (short_arm.num_nodes)
+    long_edges_parent[long_arm.tables.edges.parent > long_arm.samples()[-1]] = long_edges_parent[long_arm.tables.edges.parent > long_arm.samples()[-1]] - long_arm.num_samples
+    long_edges_child[~np.isin(long_edges_child, long_arm.samples())] = long_edges_child[~np.isin(long_edges_child, long_arm.samples())] + (short_arm.num_nodes)
+    long_edges_child[long_tables.edges.child > long_arm.samples()[-1]] = long_edges_child[long_tables.edges.child > long_arm.samples()[-1]] - long_arm.num_samples
+    long_edges_child[np.isin(long_tables.edges.child, long_arm.samples())] = long_arm_sample_map[long_tables.edges.child[np.isin(long_tables.edges.child, long_arm.samples())]]
+    short_tables.edges.append_columns(long_tables.edges.left, long_tables.edges.right, long_edges_parent, long_edges_child)
+    short_tables.sites.append_columns(long_tables.sites.position, long_tables.sites.ancestral_state, long_tables.sites.ancestral_state_offset)
+    long_mutations_node = long_tables.mutations.node
+    long_mutations_node[~np.isin(long_mutations_node, long_arm.samples())] = long_mutations_node[~np.isin(long_mutations_node, long_arm.samples())] + (short_arm.num_nodes)
+    long_mutations_node[long_tables.mutations.node > long_arm.samples()[-1]] = long_mutations_node[long_tables.mutations.node > long_arm.samples()[-1]] - long_arm.num_samples
+    long_mutations_node[np.isin(long_tables.mutations.node, long_arm.samples())] = long_arm_sample_map[long_tables.mutations.node[np.isin(long_tables.mutations.node, long_arm.samples())]]
+    short_tables.mutations.append_columns(long_tables.mutations.site + short_arm.num_sites, long_mutations_node, long_tables.mutations.derived_state, long_tables.mutations.derived_state_offset) 
+    short_tables.sort()
+    combined = short_tables.tree_sequence()
+    assert combined.num_sites == (short_arm.num_sites + long_arm.num_sites)
+    assert combined.num_edges == (short_arm.num_edges + long_arm.num_edges)
+    assert combined.num_mutations == (short_arm.num_mutations + long_arm.num_mutations)
+    assert np.array_equal(np.sort(combined.tables.sites.position), np.concatenate([short_arm.tables.sites.position, long_arm.tables.sites.position]))
+    assert np.array_equal(np.sort(combined.tables.nodes.time[combined.tables.mutations.node]), np.sort(np.concatenate([short_arm.tables.nodes.time[short_arm.tables.mutations.node], long_arm.tables.nodes.time[long_arm.tables.mutations.node]])))
+    assert np.array_equal(combined.tables.individuals.metadata, long_tables.individuals.metadata)
+    combined.dump(args.output)
+
+
 def main():
 
     parser = argparse.ArgumentParser()
@@ -688,6 +758,28 @@ def main():
     )
     subparser.add_argument("--output", type=str, help="Output sampledata filename")
     subparser.set_defaults(func=combined_ts_constrained_samples)
+
+    subparser = subparsers.add_parser("split-chromosome")
+    subparser.add_argument(
+        "input", type=str, help="Input SampleData")
+    subparser.add_argument(
+        "output", type=str, help="Output SampleData")
+    subparser.add_argument(
+        "chrom", type=str, help="Chromosome name")
+    subparser.add_argument(
+        "arm", type=str, help="Arm name")
+    subparser.add_argument(
+        "centromeres", type=str, help="CSV file containing centromere coordinates.")
+    subparser.set_defaults(func=split_chromosome)
+
+    subparser = subparsers.add_parser("combine-chromosome")
+    subparser.add_argument(
+        "p_arm", type=str, help="Input p Arm")
+    subparser.add_argument(
+        "q_arm", type=str, help="Input q Arm")
+    subparser.add_argument(
+        "output", type=str, help="Output SampleData")
+    subparser.set_defaults(func=combine_chromosome_arms)
 
     daiquiri.setup(level="INFO")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
+tskit >= 0.3.5
 pandas >= 1.2.2
-numpy >= 1.5.0
-tsdate >= 0.1.3
+numpy >= 1.20.1
 msprime >= 1.0.0a3
-tsinfer >= 0.2.0
 scikit-allel
 matplotlib
 sklearn
@@ -16,5 +15,6 @@ pyreadr
 seaborn
 mpld3
 Bio
-git+git://github.com/tskit-dev/tskit.git@main#e=tskit
+git+https://github.com/tskit-dev/tsdate.git@main#e=tsdate
+git+https://github.com/tskit-dev/tsinfer.git@main#e=tsinfer
 git+git://github.com/popsim-consortium/stdpopsim.git@main#e=stdpopsim

--- a/src/run_inference.py
+++ b/src/run_inference.py
@@ -46,15 +46,12 @@ def run(params):
             path=prefix + ".ancestors",
             progress_monitor=True,
         )
-        path_compression = True
         if np.any(params.sample_data.individuals_time[:] != 0):
             anc_w_proxy = anc.insert_proxy_samples(
                 params.sample_data, allow_mutation=True
             )
             anc = anc_w_proxy.copy(path=prefix + ".proxy.ancestors")
             anc.finalise()
-            # Don't use path compression if ancient ancestors (can be fixed in the future)
-            path_compression = True
         maximum_time = np.max(anc.ancestors_time[:])
         if maximum_time < 3: # hacky way of checking if we used frequency to order ancestors
             anc = anc.truncate_ancestors(0.4, 0.6, length_multiplier=1, path=prefix + ".truncated.ancestors")
@@ -65,7 +62,6 @@ def run(params):
         print(f"GA done (ma_mut: {params.ma_mut_rate}, ms_mut: {params.ms_mut_rate})")
     else:
         anc = tsinfer.load(prefix + ".truncated.ancestors")
-        path_compression = True
     ga_process_time = time.process_time() - ga_start_time
 
     r_prob, m_prob = get_rho(anc, params.filename)
@@ -89,7 +85,6 @@ def run(params):
             precision=precision,
             recombination=r_prob,
             mismatch=m_prob,
-            path_compression=path_compression,
             progress_monitor=True,
         )
         inferred_anc_ts.dump(prefix + ".atrees")

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,8 +5,8 @@ geva:
 	cd geva && make
 
 relate:
-	wget https://myersgroup.github.io/relate/download/relate_v1.1.5_x86_64_dynamic.tgz
-	tar -xzf relate_v1.1.5_x86_64_dynamic.tgz
+	wget https://myersgroup.github.io/relate/download/relate_v1.1.6_x86_64_dynamic.tgz
+	tar -xzf relate_v1.1.6_x86_64_dynamic.tgz
 	mv relate_v1.1.5_x86_64_dynamic relate 
 
 htslib:


### PR DESCRIPTION
Adds:

- code to truncate old ancestors (including necessary adjustments to the rate maps passed to `tsinfer`)
- splits chromosomes for inference
- adds code for plotting part of figure 3 and supplemental figure 8